### PR TITLE
Set VideoCapture buffer size to 1 frame to reduce latency

### DIFF
--- a/virtual_webcam.py
+++ b/virtual_webcam.py
@@ -82,6 +82,10 @@ if config.get("width"):
 if config.get("height"):
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, config.get("height"))
 
+# Attempt to reduce the buffer size
+if not cap.set(cv2.CAP_PROP_BUFFERSIZE, 1):
+    print('Failed to reduce capture buffer size. Latency will be higher!')
+
 # Get the actual resolution (either webcam default or the configured one)
 width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
 height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))


### PR DESCRIPTION
Quite impressed with this project. On low resolutions the performance is acceptable, but there was still a very noticeable latency. Looking into it a bit more, it seems that there's a buffer in opencv for v4l2 devices. By default it will hold 4 frames, and reducing this to only 1 seems to reduce latency noticeably.