### PR TITLE
Workaround for disabled GPU by tfjs_graph_converter

### DIFF
--- a/virtual_webcam.py
+++ b/virtual_webcam.py
@@ -5,8 +5,19 @@ import os
 import yaml
 
 import tensorflow as tf
+
+# since oct 2020, tfjs_graph_converter disables GPU acceleration.
+# this works around that problem by restoring it after the inclusion, see
+# https://github.com/patlevin/tfjs-to-tf/issues/35
+cuda_devices = os.getenv('CUDA_VISIBLE_DEVICES')
+
 import tfjs_graph_converter.api as tfjs_api
 import tfjs_graph_converter.util as tfjs_util
+
+if cuda_devices is None:
+    os.unsetenv('CUDA_VISIBLE_DEVICES')
+else:
+    os.putenv('CUDA_VISIBLE_DEVICES', cuda_devices)
 
 try:
     import mediapipe as mp


### PR DESCRIPTION
Since end of 2020, including tfjs_graph_converter disables tensorflow GPU acceleration globally.

I have created an issue on that over [there](https://github.com/patlevin/tfjs-to-tf/issues/35).

Until this is fixed, i think its reasonable to implement a workaround so GPU acceleration is utilized when available.

